### PR TITLE
Adds plugin and details to upload to JCenter via bintray

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,4 +16,9 @@ allprojects {
     repositories {
         jcenter()
     }
+    buildscript {
+        repositories {
+            jcenter()
+        }
+    }
 }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -15,6 +15,7 @@
  */
 
 apply plugin: 'com.android.library'
+apply plugin: 'bintray-release'
 
 android {
     compileSdkVersion 21
@@ -28,6 +29,22 @@ android {
     }
 }
 
+publish {
+    // https://github.com/novoda/bintray-release/wiki/Configuration-of-the-publish-closure
+    userOrg = 'adw'
+    groupId = 'org.adw.library'
+    artifactId = 'discreteseekbar'
+    version = '1.0.0'
+    description = 'DiscreteSeekbar is my poor attempt to develop an android implementation ' +
+            'of the DiscreteSlider component from the Google Material Design Guidelines.'
+    website = 'https://github.com/AnderWeb/discreteSeekBar'
+}
+
 dependencies {
     compile 'com.android.support:support-v4:21.0.2'
+}
+buildscript {
+    dependencies {
+        classpath 'com.novoda:bintray-release:0.2.5'
+    }
 }


### PR DESCRIPTION
Uses this plugin https://github.com/novoda/bintray-release to make the library releaseable to `JCenter()`.

(after bintray website setup)
You can release with this command:

`./gradlew clean build bintrayUpload -PdryRun=false -PbintrayUser=BINTRAY_USERNAME -PbintrayKey=BINTRAY_KEY `

I just added the minimum config to the release details, but you can add a lot more if you want: https://github.com/novoda/bintray-release/wiki/Configuration-of-the-publish-closure

Obviously the details are your choice, I just picked some sane defaults:

```groovy
    userOrg = 'adw'
    groupId = 'org.adw.library'
    artifactId = 'discreteseekbar'
```

Before you can push your release to BinTray you need to sign up by following these steps, which are straight forward enough: https://bintray.com/howbintrayworks#page11

You can test your release with `-PdryRun=true` and it will create the files but not push them up the BinTray, if you are interested under the hood it performs the same actions as this http://blog.blundell-apps.com/locally-release-an-android-library-for-jcenter-or-maven-central-inclusion/ 