### PR TITLE
Add ability to set thumb color as well as scrubber color programmatically. Add new NumericStringTransformer

### DIFF
--- a/library/src/main/java/org/adw/library/widgets/discreteseekbar/DiscreteSeekBar.java
+++ b/library/src/main/java/org/adw/library/widgets/discreteseekbar/DiscreteSeekBar.java
@@ -21,6 +21,7 @@ import android.content.res.ColorStateList;
 import android.content.res.TypedArray;
 import android.graphics.Canvas;
 import android.graphics.Color;
+import android.graphics.PorterDuff;
 import android.graphics.Rect;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
@@ -79,8 +80,8 @@ public class DiscreteSeekBar extends View {
         /**
          * Return the desired value to be shown to the user.
          *
-         * @param value
-         * @return
+         * @param value The value to be transformed
+         * @return The transformed int
          */
         public int transformToInt(int value);
 
@@ -133,7 +134,6 @@ public class DiscreteSeekBar extends View {
     private Drawable mScrubber;
     private Drawable mRipple;
 
-    private int mThumbSize;
     private int mTrackHeight;
     private int mScrubberHeight;
     private int mAddedTouchBounds;
@@ -178,11 +178,11 @@ public class DiscreteSeekBar extends View {
         float density = context.getResources().getDisplayMetrics().density;
         mTrackHeight = (int) (1 * density);
         mScrubberHeight = (int) (4 * density);
-        mThumbSize = (int) (density * ThumbDrawable.DEFAULT_SIZE_DP);
+        int thumbSize = (int) (density * ThumbDrawable.DEFAULT_SIZE_DP);
 
         //Extra pixels for a touch area of 48dp
         int touchBounds = (int) (density * 32);
-        mAddedTouchBounds = (touchBounds - mThumbSize) / 2;
+        mAddedTouchBounds = (touchBounds - thumbSize) / 2;
 
 
         TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.DiscreteSeekBar,
@@ -257,7 +257,7 @@ public class DiscreteSeekBar extends View {
         mScrubber = shapeDrawable;
         mScrubber.setCallback(this);
 
-        ThumbDrawable thumbDrawable = new ThumbDrawable(progressColor, mThumbSize);
+        ThumbDrawable thumbDrawable = new ThumbDrawable(progressColor, thumbSize);
         mThumb = thumbDrawable;
         mThumb.setCallback(this);
         mThumb.setBounds(0, 0, mThumb.getIntrinsicWidth(), mThumb.getIntrinsicHeight());
@@ -419,15 +419,14 @@ public class DiscreteSeekBar extends View {
     }
 
     /**
-     * Sets the color of the seek thumb, as well as the color of the floating indicator bubble.
+     * Sets the color of the seek thumb, as well as the color of the popup indicator.
      *
-     * @param color The color the seek thumb will be changed to
+     * @param startColor The color the seek thumb will be changed to
+     * @param endColor   The color the popup indicator will be changed to
      */
-    public void setThumbColor(int color) {
-        mThumb = new ThumbDrawable(ColorStateList.valueOf(color), mThumbSize);
-        mThumb.setCallback(this);
-        mThumb.setBounds(0, 0, mThumb.getIntrinsicWidth(), mThumb.getIntrinsicHeight());
-        mIndicator.setColor(color);
+    public void setThumbColor(int startColor, int endColor) {
+        mThumb.setColorStateList(ColorStateList.valueOf(startColor));
+        mIndicator.setColors(startColor, endColor);
     }
 
     /**
@@ -436,8 +435,7 @@ public class DiscreteSeekBar extends View {
      * @param color The color the track will be changed to
      */
     public void setScrubberColor(int color) {
-        mScrubber = new TrackRectDrawable(ColorStateList.valueOf(color));
-        mScrubber.setCallback(this);
+        mScrubber.setColorFilter(color, PorterDuff.Mode.SRC_ATOP);
     }
 
     private void notifyProgress(int value, boolean fromUser) {
@@ -964,4 +962,3 @@ public class DiscreteSeekBar extends View {
                 };
     }
 }
-

--- a/library/src/main/java/org/adw/library/widgets/discreteseekbar/internal/Marker.java
+++ b/library/src/main/java/org/adw/library/widgets/discreteseekbar/internal/Marker.java
@@ -50,6 +50,7 @@ public class Marker extends ViewGroup implements MarkerDrawable.MarkerAnimationL
     private static final int PADDING_DP = 4;
     private static final int ELEVATION_DP = 8;
     private static final int SEPARATION_DP = 30;
+    private final int PADDING_PX;
     //The TextView to show the info
     private TextView mNumber;
     //The max width of this View
@@ -57,6 +58,7 @@ public class Marker extends ViewGroup implements MarkerDrawable.MarkerAnimationL
     //some distance between the thumb and our bubble marker.
     //This will be added to our measured height
     private int mSeparation;
+    private int mThumbSize;
     MarkerDrawable mMarkerDrawable;
 
     public Marker(Context context) {
@@ -77,12 +79,12 @@ public class Marker extends ViewGroup implements MarkerDrawable.MarkerAnimationL
         TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.DiscreteSeekBar,
                 R.attr.discreteSeekBarStyle, R.style.DefaultSeekBar);
 
-        int padding = (int) (PADDING_DP * displayMetrics.density) * 2;
+        PADDING_PX = (int) (PADDING_DP * displayMetrics.density) * 2;
         int textAppearanceId = a.getResourceId(R.styleable.DiscreteSeekBar_dsb_indicatorTextAppearance,
                 R.style.DefaultIndicatorTextAppearance);
         mNumber = new TextView(context);
         //Add some padding to this textView so the bubble has some space to breath
-        mNumber.setPadding(padding, 0, padding, 0);
+        mNumber.setPadding(PADDING_PX, 0, PADDING_PX, 0);
         mNumber.setTextAppearance(context, textAppearanceId);
         mNumber.setGravity(Gravity.CENTER);
         mNumber.setText(maxValue);
@@ -93,17 +95,17 @@ public class Marker extends ViewGroup implements MarkerDrawable.MarkerAnimationL
 
         //add some padding for the elevation shadow not to be clipped
         //I'm sure there are better ways of doing this...
-        setPadding(padding, padding, padding, padding);
+        setPadding(PADDING_PX, PADDING_PX, PADDING_PX, PADDING_PX);
 
         resetSizes(maxValue);
 
         mSeparation = (int) (SEPARATION_DP * displayMetrics.density);
-        int thumbSize = (int) (ThumbDrawable.DEFAULT_SIZE_DP * displayMetrics.density);
+        mThumbSize = (int) (ThumbDrawable.DEFAULT_SIZE_DP * displayMetrics.density);
         ColorStateList color = a.getColorStateList(R.styleable.DiscreteSeekBar_dsb_indicatorColor);
-        mMarkerDrawable = new MarkerDrawable(color, thumbSize);
+        mMarkerDrawable = new MarkerDrawable(color, mThumbSize);
         mMarkerDrawable.setCallback(this);
         mMarkerDrawable.setMarkerListener(this);
-        mMarkerDrawable.setExternalOffset(padding);
+        mMarkerDrawable.setExternalOffset(PADDING_PX);
 
         //Elevation for anroid 5+
         float elevation = a.getDimension(R.styleable.DiscreteSeekBar_dsb_indicatorElevation, ELEVATION_DP * displayMetrics.density);
@@ -227,5 +229,12 @@ public class Marker extends ViewGroup implements MarkerDrawable.MarkerAnimationL
     protected void onDetachedFromWindow() {
         super.onDetachedFromWindow();
         mMarkerDrawable.stop();
+    }
+
+    public void setColor(int color) {
+        mMarkerDrawable = new MarkerDrawable(ColorStateList.valueOf(color), mThumbSize);
+        mMarkerDrawable.setCallback(this);
+        mMarkerDrawable.setMarkerListener(this);
+        mMarkerDrawable.setExternalOffset(PADDING_PX);
     }
 }

--- a/library/src/main/java/org/adw/library/widgets/discreteseekbar/internal/Marker.java
+++ b/library/src/main/java/org/adw/library/widgets/discreteseekbar/internal/Marker.java
@@ -50,7 +50,6 @@ public class Marker extends ViewGroup implements MarkerDrawable.MarkerAnimationL
     private static final int PADDING_DP = 4;
     private static final int ELEVATION_DP = 8;
     private static final int SEPARATION_DP = 30;
-    private final int PADDING_PX;
     //The TextView to show the info
     private TextView mNumber;
     //The max width of this View
@@ -58,7 +57,6 @@ public class Marker extends ViewGroup implements MarkerDrawable.MarkerAnimationL
     //some distance between the thumb and our bubble marker.
     //This will be added to our measured height
     private int mSeparation;
-    private int mThumbSize;
     MarkerDrawable mMarkerDrawable;
 
     public Marker(Context context) {
@@ -79,12 +77,12 @@ public class Marker extends ViewGroup implements MarkerDrawable.MarkerAnimationL
         TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.DiscreteSeekBar,
                 R.attr.discreteSeekBarStyle, R.style.DefaultSeekBar);
 
-        PADDING_PX = (int) (PADDING_DP * displayMetrics.density) * 2;
+        int padding = (int) (PADDING_DP * displayMetrics.density) * 2;
         int textAppearanceId = a.getResourceId(R.styleable.DiscreteSeekBar_dsb_indicatorTextAppearance,
                 R.style.DefaultIndicatorTextAppearance);
         mNumber = new TextView(context);
         //Add some padding to this textView so the bubble has some space to breath
-        mNumber.setPadding(PADDING_PX, 0, PADDING_PX, 0);
+        mNumber.setPadding(padding, 0, padding, 0);
         mNumber.setTextAppearance(context, textAppearanceId);
         mNumber.setGravity(Gravity.CENTER);
         mNumber.setText(maxValue);
@@ -95,17 +93,17 @@ public class Marker extends ViewGroup implements MarkerDrawable.MarkerAnimationL
 
         //add some padding for the elevation shadow not to be clipped
         //I'm sure there are better ways of doing this...
-        setPadding(PADDING_PX, PADDING_PX, PADDING_PX, PADDING_PX);
+        setPadding(padding, padding, padding, padding);
 
         resetSizes(maxValue);
 
         mSeparation = (int) (SEPARATION_DP * displayMetrics.density);
-        mThumbSize = (int) (ThumbDrawable.DEFAULT_SIZE_DP * displayMetrics.density);
+        int thumbSize = (int) (ThumbDrawable.DEFAULT_SIZE_DP * displayMetrics.density);
         ColorStateList color = a.getColorStateList(R.styleable.DiscreteSeekBar_dsb_indicatorColor);
-        mMarkerDrawable = new MarkerDrawable(color, mThumbSize);
+        mMarkerDrawable = new MarkerDrawable(color, thumbSize);
         mMarkerDrawable.setCallback(this);
         mMarkerDrawable.setMarkerListener(this);
-        mMarkerDrawable.setExternalOffset(PADDING_PX);
+        mMarkerDrawable.setExternalOffset(padding);
 
         //Elevation for anroid 5+
         float elevation = a.getDimension(R.styleable.DiscreteSeekBar_dsb_indicatorElevation, ELEVATION_DP * displayMetrics.density);
@@ -231,10 +229,7 @@ public class Marker extends ViewGroup implements MarkerDrawable.MarkerAnimationL
         mMarkerDrawable.stop();
     }
 
-    public void setColor(int color) {
-        mMarkerDrawable = new MarkerDrawable(ColorStateList.valueOf(color), mThumbSize);
-        mMarkerDrawable.setCallback(this);
-        mMarkerDrawable.setMarkerListener(this);
-        mMarkerDrawable.setExternalOffset(PADDING_PX);
+    public void setColors(int startColor, int endColor) {
+        mMarkerDrawable.setColors(startColor, endColor);
     }
 }

--- a/library/src/main/java/org/adw/library/widgets/discreteseekbar/internal/PopupIndicator.java
+++ b/library/src/main/java/org/adw/library/widgets/discreteseekbar/internal/PopupIndicator.java
@@ -121,6 +121,9 @@ public class PopupIndicator {
         translateViewIntoPosition(x);
     }
 
+    public void setColors(int startColor, int endColor) {
+        mPopupView.setColors(startColor, endColor);
+    }
 
     /**
      * This will start the closing animation of the Marker and call onClosingComplete when finished
@@ -199,10 +202,6 @@ public class PopupIndicator {
         return curFlags;
     }
 
-    public void setColor(int color) {
-        mPopupView.setColor(color);
-    }
-
     /**
      * Small FrameLayout class to hold and move the bubble around when requested
      * I wanted to use the {@link Marker} directly
@@ -261,8 +260,8 @@ public class PopupIndicator {
             }
         }
 
-        public void setColor(int color) {
-            mMarker.setColor(color);
+        public void setColors(int startColor, int endColor) {
+            mMarker.setColors(startColor, endColor);
         }
     }
 

--- a/library/src/main/java/org/adw/library/widgets/discreteseekbar/internal/PopupIndicator.java
+++ b/library/src/main/java/org/adw/library/widgets/discreteseekbar/internal/PopupIndicator.java
@@ -199,9 +199,13 @@ public class PopupIndicator {
         return curFlags;
     }
 
+    public void setColor(int color) {
+        mPopupView.setColor(color);
+    }
+
     /**
      * Small FrameLayout class to hold and move the bubble around when requested
-     * I wanted to use the {@link org.adw.library.widgets.discreteseekbar.internal.Marker} directly
+     * I wanted to use the {@link Marker} directly
      * but doing so would make some things harder to implement
      * (like moving the marker around, having the Marker's outline to work, etc)
      */
@@ -257,6 +261,9 @@ public class PopupIndicator {
             }
         }
 
+        public void setColor(int color) {
+            mMarker.setColor(color);
+        }
     }
 
 }

--- a/library/src/main/java/org/adw/library/widgets/discreteseekbar/internal/drawable/MarkerDrawable.java
+++ b/library/src/main/java/org/adw/library/widgets/discreteseekbar/internal/drawable/MarkerDrawable.java
@@ -31,9 +31,9 @@ import android.view.animation.AccelerateDecelerateInterpolator;
 import android.view.animation.Interpolator;
 
 /**
- * Implementation of {@link org.adw.library.widgets.discreteseekbar.internal.drawable.StateDrawable} to draw a morphing marker symbol.
+ * Implementation of {@link StateDrawable} to draw a morphing marker symbol.
  * <p>
- * It's basically an implementatin of an {@link android.graphics.drawable.Animatable} Drawable with the following details:
+ * It's basically an implementation of an {@link android.graphics.drawable.Animatable} Drawable with the following details:
  * </p>
  * <ul>
  * <li>Animates from a circle shape to a "marker" shape just using a RoundRect</li>
@@ -80,6 +80,17 @@ public class MarkerDrawable extends StateDrawable implements Animatable {
 
     public void setExternalOffset(int offset) {
         mExternalOffset = offset;
+    }
+
+    /**
+     * The two colors that will be used for the seek thumb.
+     *
+     * @param startColor Color used for the seek thumb
+     * @param endColor   Color used for popup indicator
+     */
+    public void setColors(int startColor, int endColor) {
+        mStartColor = startColor;
+        mEndColor = endColor;
     }
 
     @Override

--- a/library/src/main/java/org/adw/library/widgets/discreteseekbar/internal/drawable/StateDrawable.java
+++ b/library/src/main/java/org/adw/library/widgets/discreteseekbar/internal/drawable/StateDrawable.java
@@ -34,7 +34,7 @@ import android.support.annotation.NonNull;
  * @hide
  */
 public abstract class StateDrawable extends Drawable {
-    private final ColorStateList mTintStateList;
+    private ColorStateList mTintStateList;
     private final Paint mPaint;
     private int mCurrentColor;
     private int mAlpha = 255;
@@ -80,6 +80,10 @@ public abstract class StateDrawable extends Drawable {
         int alpha = modulateAlpha(Color.alpha(mCurrentColor));
         mPaint.setAlpha(alpha);
         doDraw(canvas, mPaint);
+    }
+
+    public void setColorStateList(@NonNull ColorStateList tintStateList) {
+        mTintStateList = tintStateList;
     }
 
     /**


### PR DESCRIPTION
The first change I made to the public API were methods to change the color of the thumb and the scrubber, because I need them to be themed dynamically. Changing the color of the thumb also changes the color of the popup indicator to the same color. 

The second change I made was the addition of a new numeric transformer called NumericStringTransformer. It's a more generic version of NumericTransformer, and its transform method directly returns a String, so if the user needs to do something more complicated than show a number or apply a format to a number, such as taking a number in milliseconds, and converting it to HH:MM:SS, they have more control over the final display of the popup indicator. If the NumericStringTransformer is set, the library will now prefer it over the NumericTransformer's transform. In my opinion, since this is a more powerful/generic version of NumericTransformer, NumericTransformer can be deprecated because its functionalities are duplicated by NumericStringTransformer.