### PR TITLE
Fixed some bugs and updated sdk & Library version

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -34,12 +34,12 @@ def libVersion = '1.0.1'
 
 
 android {
-    compileSdkVersion 22
-    buildToolsVersion '22.0.1'
+    compileSdkVersion 23
+    buildToolsVersion '23.0.2'
 
     defaultConfig {
         minSdkVersion 4
-        targetSdkVersion 22
+        targetSdkVersion 23
         versionCode libVersionCode
         versionName libVersion
     }
@@ -73,5 +73,5 @@ publish {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:22.1.1'
+    compile 'com.android.support:support-v4:23.1.1'
 }

--- a/library/src/main/java/org/adw/library/widgets/discreteseekbar/DiscreteSeekBar.java
+++ b/library/src/main/java/org/adw/library/widgets/discreteseekbar/DiscreteSeekBar.java
@@ -339,6 +339,8 @@ public class DiscreteSeekBar extends View {
         }
         //We need to refresh the PopupIndicator view
         updateIndicatorSizes();
+        //Fix Wrong behavior while changing Max value on RealTime
+        updateThumbPosFromCurrentProgress();
     }
 
     public int getMax() {
@@ -367,6 +369,8 @@ public class DiscreteSeekBar extends View {
         if (mValue < mMin || mValue > mMax) {
             setProgress(mMin);
         }
+        updateIndicatorSizes();
+        updateThumbPosFromCurrentProgress();
     }
 
     public int getMin() {
@@ -1004,7 +1008,7 @@ public class DiscreteSeekBar extends View {
     }
 
     public boolean isRtl() {
-        return (ViewCompat.getLayoutDirection(this) == LAYOUT_DIRECTION_RTL) && mMirrorForRtl;
+        return (ViewCompat.getLayoutDirection(this) == ViewCompat.LAYOUT_DIRECTION_RTL) && mMirrorForRtl;
     }
 
     @Override

--- a/library/src/main/java/org/adw/library/widgets/discreteseekbar/internal/Marker.java
+++ b/library/src/main/java/org/adw/library/widgets/discreteseekbar/internal/Marker.java
@@ -105,6 +105,8 @@ public class Marker extends ViewGroup implements MarkerDrawable.MarkerAnimationL
     public void resetSizes(String maxValue) {
         DisplayMetrics displayMetrics = getResources().getDisplayMetrics();
         //Account for negative numbers... is there any proper way of getting the biggest string between our range????
+        //Save current Value:
+        CharSequence currentNumber = mNumber.getText();
         mNumber.setText("-" + maxValue);
         //Do a first forced measure call for the TextView (with the biggest text content),
         //to calculate the max width and use always the same.
@@ -115,6 +117,8 @@ public class Marker extends ViewGroup implements MarkerDrawable.MarkerAnimationL
         mWidth = Math.max(mNumber.getMeasuredWidth(), mNumber.getMeasuredHeight());
         removeView(mNumber);
         addView(mNumber, new FrameLayout.LayoutParams(mWidth, mWidth, Gravity.LEFT | Gravity.TOP));
+        // Retrieve saved value
+        mNumber.setText(currentNumber);
     }
 
     @Override

--- a/library/src/main/java/org/adw/library/widgets/discreteseekbar/internal/drawable/AlmostRippleDrawable.java
+++ b/library/src/main/java/org/adw/library/widgets/discreteseekbar/internal/drawable/AlmostRippleDrawable.java
@@ -24,7 +24,7 @@ import android.graphics.Rect;
 import android.graphics.drawable.Animatable;
 import android.os.SystemClock;
 import android.support.annotation.NonNull;
-import android.view.animation.AccelerateDecelerateInterpolator;
+import android.support.v4.view.animation.FastOutSlowInInterpolator;
 import android.view.animation.Interpolator;
 
 public class AlmostRippleDrawable extends StateDrawable implements Animatable {
@@ -49,7 +49,7 @@ public class AlmostRippleDrawable extends StateDrawable implements Animatable {
 
     public AlmostRippleDrawable(@NonNull ColorStateList tintStateList) {
         super(tintStateList);
-        mInterpolator = new AccelerateDecelerateInterpolator();
+        mInterpolator = new FastOutSlowInInterpolator();
         setColor(tintStateList);
     }
 

--- a/library/src/main/java/org/adw/library/widgets/discreteseekbar/internal/drawable/MarkerDrawable.java
+++ b/library/src/main/java/org/adw/library/widgets/discreteseekbar/internal/drawable/MarkerDrawable.java
@@ -27,7 +27,7 @@ import android.graphics.RectF;
 import android.graphics.drawable.Animatable;
 import android.os.SystemClock;
 import android.support.annotation.NonNull;
-import android.view.animation.AccelerateDecelerateInterpolator;
+import android.support.v4.view.animation.FastOutSlowInInterpolator;
 import android.view.animation.Interpolator;
 
 /**
@@ -71,7 +71,7 @@ public class MarkerDrawable extends StateDrawable implements Animatable {
 
     public MarkerDrawable(@NonNull ColorStateList tintList, int closedSize) {
         super(tintList);
-        mInterpolator = new AccelerateDecelerateInterpolator();
+        mInterpolator = new FastOutSlowInInterpolator();
         mClosedStateSize = closedSize;
         mStartColor = tintList.getColorForState(new int[]{android.R.attr.state_enabled, android.R.attr.state_pressed}, tintList.getDefaultColor());
         mEndColor = tintList.getDefaultColor();


### PR DESCRIPTION
**\- Fixed:** Calling `setMax` on realtime didn't update progress postion. for more information about this bug refer to issue #50.
**\- Fixed:** Leaving wrong value after measuring maximum `Marker`width.
**\- Changed:** `AccelerateDecelerateInterpolator` to `FastOutSlowInInterpolator` (this is material design interpolator provided by google in support library v4).
**\- Updated:** target sdk and support library.
