### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#DiscreteSeekBar
+# DiscreteSeekBar
 
 ![screenshot](https://lh6.googleusercontent.com/-JjvxVMCm1ug/VHUPWVBfpbI/AAAAAAAAHtQ/TPtoOjHI5MA/w639-h356/seekbar2.gif)
 
@@ -6,10 +6,10 @@
 
 DiscreteSeekbar is my poor attempt to develop an android implementation of the [Discrete Slider] component from the Google Material Design Guidelines.
 
-##Prologe
+## Prologe
 I really hope Google provides developers with a better (and official) implementation ;)
 
-##Warning
+## Warning
 After a bunch of hours trying to replicate the exact feel of the Material's Discrete Seekbar, with a beautiful stuff-that-morphs-into-other-stuff animation I was convinced about releasing the current code.
 
 ```java
@@ -17,7 +17,7 @@ android.util.Log.wtf("WARNING!! HACKERY-DRAGONS!!");
 ```
 I've done a few bit of hacky cede and a bunch of things I'm not completely proud of, so use under your sole responsibility (or help me improve it via pull-requests!)
 
-##Implementation details
+## Implementation details
 This thing runs on minSDK=7 (well, technically could run 4 but can't test since AVDs for api 4 are deprecated and just don't boot).
 Obviously some of the subtle animations (navigating with the Keyboard, the Ripple effect, text fade ins/fade outs, etc) are not going to work on APIS lower than 11, but the bubble thing does. And I haven't found a way of improving this with 11-21 APIs, so...
 
@@ -33,10 +33,10 @@ The material-floating-thing is composed into the WindowManager (like the typical
 
 >For this I'm not sure about the amounts of things I've copied from [PopupWindow] and the possible issues.
 
-##Dependencies
+## Dependencies
 It uses **com.android.support:support-v4** as the only dependency.
 
-##Usage
+## Usage
 This is published in jCenter so you need to use the appropiate repo:
 
 ```groovy
@@ -60,7 +60,7 @@ Once imported into your project, you just need to put them into your layous like
 />
 ```
 
-####Parameters
+#### Parameters
 You can tweak a few things of the DiscreteSeekbar:
 
 * **dsb_min**: minimum value
@@ -71,7 +71,7 @@ You can tweak a few things of the DiscreteSeekbar:
 * **dsb_indicatorFormatter**: a string [Format] to apply to the value inside the bubble indicator.
 * **dsb_indicatorPopupEnabled**: choose if the bubble indicator will be shown. Default TRUE 
 
-####Design
+#### Design
  
 * **dsb_progressColor**: color/colorStateList for the progress bar and thumb drawable
 * **dsb_trackColor**: color/colorStateList for the track drawable
@@ -86,7 +86,7 @@ You can tweak a few things of the DiscreteSeekbar:
 
 You can also use the attribute **discreteSeekBarStyle** on your themes with a custom Style to be applied to all the DiscreteSeekBars on your app/activity/fragment/whatever.
 
-##License
+## License
 ```
 Copyright 2014 Gustavo Claramunt (Ander Webbs)
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
